### PR TITLE
Colorfield is required for reports

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "require": {
         "silverstripe/framework": "~3.1",
         "silverstripe-australia/gridfieldextensions": "*",
-        "silverstripe/userforms": "2.0.10"
+        "silverstripe/userforms": "2.0.10",
+        "colymba/silverstripe-colorfield": "*"
     },
     "extra": {
         "installer-name": "consultations"

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,8 @@
     "name": "dnadesign/silverstripe-consultations",
     "description": "Build consultation forms for community engagement.",
     "type": "silverstripe-module",
+    "minimum-stability": "dev",
+    "prefer-stable" : true,
     "keywords": ["silverstripe", "consultation", "engagement", "form"],
 	"license": "BSD-3-Clause",
     "authors": [{

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d497cb108d05cef20c051da0a0e95712",
+    "hash": "7f52b43d6b00ac5adad55bc691eccb74",
     "packages": [
         {
             "name": "composer/installers",
@@ -294,9 +294,9 @@
     ],
     "packages-dev": [],
     "aliases": [],
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "stability-flags": [],
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": []

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,47 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "7f52b43d6b00ac5adad55bc691eccb74",
+    "hash": "593073598342c18c4347bae0c9b03574",
     "packages": [
+        {
+            "name": "colymba/silverstripe-colorfield",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/colymba/silverstripe-colorfield.git",
+                "reference": "ab241b67c237d138ab3c5aca85294aae69f6b9e3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/colymba/silverstripe-colorfield/zipball/ab241b67c237d138ab3c5aca85294aae69f6b9e3",
+                "reference": "ab241b67c237d138ab3c5aca85294aae69f6b9e3",
+                "shasum": ""
+            },
+            "require": {
+                "silverstripe/framework": ">=3"
+            },
+            "type": "silverstripe-module",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD Simplified"
+            ],
+            "authors": [
+                {
+                    "name": "Thierry Francois",
+                    "email": "thierry@colymba.com"
+                }
+            ],
+            "description": "SilverStripe 3 Color picker and DBField field with attitude.",
+            "keywords": [
+                "color",
+                "color picker",
+                "colour",
+                "colour field",
+                "dbfield",
+                "silverstripe"
+            ],
+            "time": "2014-11-28 17:48:01"
+        },
         {
             "name": "composer/installers",
             "version": "v1.0.21",


### PR DESCRIPTION
Performed a basic install when trying to create a report it was looking for the class ColorField and produced the following error

PHP Fatal error:  Class 'ColorField' not found

Added the colymba/silverstripe-colorfield module had to amend the minimum stability to allow the module to be installed.
