### PR TITLE
Join the SubmittedFormField to the valid option to stop other field v…

### DIFF
--- a/code/models/ConsultationReport.php
+++ b/code/models/ConsultationReport.php
@@ -79,7 +79,10 @@ class ConsultationReport extends DataObject {
 				array(
 					'ParentID' => $this->Consultation()->Submissions()->column('ID'),
 					// confirm the value actually belongs to the correct form field
-					'Name' => "EditableDropdown$parentID",
+					'Name' => array(
+						"EditableDropdown$parentID",
+						"EditableRadioField$parentID"
+					),
 					'Value' => $option->Title
 				)
 			);

--- a/code/models/ConsultationReport.php
+++ b/code/models/ConsultationReport.php
@@ -74,7 +74,15 @@ class ConsultationReport extends DataObject {
 
 		$options = $this->Field()->Options();
 		foreach($options as $option) {
-			$result = SubmittedFormField::get()->filter(array('ParentID' => $this->Consultation()->Submissions()->column('ID'), 'Value' => $option->Title));
+			$parentID = $option->ParentID;
+			$result = SubmittedFormField::get()->filter(
+				array(
+					'ParentID' => $this->Consultation()->Submissions()->column('ID'),
+					// confirm the value actually belongs to the correct form field
+					'Name' => "EditableDropdown$parentID",
+					'Value' => $option->Title
+				)
+			);
 			$optionResult = [];
 			$optionResult['Label'] = $option->Title;
 			$optionResult['Value'] = $result->count();

--- a/code/models/ConsultationReport.php
+++ b/code/models/ConsultationReport.php
@@ -79,7 +79,11 @@ class ConsultationReport extends DataObject {
 				array(
 					'ParentID' => $this->Consultation()->Submissions()->column('ID'),
 					// confirm the value actually belongs to the correct form field
-					'Name' => "EditableDropdown$parentID",
+					'Name' => array(
+						"EditableDropdown$parentID",
+						"EditableCheckboxGroupField$parentID",
+						"EditableRadioField$parentID"
+					),
 					'Value' => $option->Title
 				)
 			);


### PR DESCRIPTION
Created a form with different options and a few text fields.
When submitting the form and entering the value from one of the options into the text fields this skewed the results.
So if one of the options had the value 'A' and I selected it and Entered 'A' into one of the text fields this would count as 2 submissions for the dropdown option 'A'.

See the screen dump which show shows 4 form submissions but 6 entries for the doughnut chart

![skewedresults](https://cloud.githubusercontent.com/assets/1495580/8691083/25606118-2b12-11e5-9504-d5ef5e4ab995.png)

This patch fixes this issue by getting the parent ID of the option and using it in a filter against the Name column inSubmittedFormFields
